### PR TITLE
Resolve IndexErrors with get_motif_pairs in DataLoader

### DIFF
--- a/birdclef/utils.py
+++ b/birdclef/utils.py
@@ -56,17 +56,42 @@ def load_audio(input_path: Path, offset: float, duration: int = 7, sr: int = 320
     return np.resize(np.moveaxis(y_trunc, -1, 0), length)
 
 
-def slice_seconds(data, sample_rate, seconds=5, pad_seconds=0):
+def slice_seconds(data, sample_rate, seconds=5, pad_seconds=0, padding_type="center"):
     # return 2d array of the original data
-    n = len(data)
+    valid_padding_types = ["center", "right", "right-align"]
+    if padding_type not in valid_padding_types:
+        raise ValueError(f"padding_type must be one of: {valid_padding_types}")
+
+    # compute step size
     k = sample_rate * seconds
     pad = sample_rate * pad_seconds
+    step = k + pad
+
+    remainder = len(data) % step
+    if remainder:
+        # pad dataset based on padding type
+        padding_size = step - remainder
+        if padding_type == "right":
+            data = np.pad(data, (0, padding_size))
+        elif padding_type == "center":
+            left_padding = padding_size // 2
+            right_padding = left_padding if padding_size % 2 == 0 else left_padding + 1
+            data = np.pad(data, (left_padding, right_padding))
+        elif padding_type == "right-align":
+            # Get a full slice from the right side, then truncate the data
+            # to divide evenly by step size.  Append the full slice to the end.
+            last_slice = data[-step:]
+            remaining_data = data[: (len(data) // step * step)]
+            data = np.hstack((remaining_data, last_slice))
+
+    n = len(data)
     indexes = np.array(
-        [np.arange(i, i + k + pad) for i in range(0, n, k) if i + k + pad <= n]
+        [np.arange(i, i + step) for i in range(0, n, k) if i + step <= n]
     ).astype(int)
     indexed = data[indexes]
     if indexed.shape[0] == 0:
         return []
+
     time_index = np.arange(indexed.shape[0] + 1) * seconds
     return list(zip(time_index, indexed))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,10 +48,49 @@ def test_load_audio_short_centered(tone_short, sr):
     assert (y[-sr:] > 0).sum() == 0
 
 
-def test_slice_seconds():
+def test_slice_seconds_right_pad():
     x = np.ones(16)
-    res = slice_seconds(x, 1, 5)
-    assert len(res) == 3
-    i, v = res[1]
-    assert i == 5
+    res = slice_seconds(x, 1, 5, remainder_padding_type="right")
+    assert len(res) == 4
+
+    # assert 1st slice is correct
+    i, v = res[0]
+    assert i == 0
     assert (v - np.ones(5)).sum() == 0
+
+    # assert last slice is right-padded correctly
+    i, v = res[3]
+    assert i == 15
+    assert (v - np.array([1, 0, 0, 0, 0])).sum() == 0
+
+
+def test_slice_seconds_center_pad():
+    x = np.ones(17)
+    res = slice_seconds(x, 1, 5, remainder_padding_type="center")
+    assert len(res) == 4
+
+    # assert 1st slice is correct
+    i, v = res[0]
+    assert i == 0
+    assert (v - np.array([0, 1, 1, 1, 1])).sum() == 0
+
+    # assert last slice is center-padded correctly
+    i, v = res[3]
+    assert i == 15
+    assert (v - np.array([1, 1, 1, 0, 0])).sum() == 0
+
+
+def test_slice_seconds_right_aligned_pad():
+    x = np.arange(1, 8)
+    res = slice_seconds(x, 1, 5, remainder_padding_type="right-aligned")
+    assert len(res) == 2
+
+    # assert 1st slice is correct
+    i, v = res[0]
+    assert i == 0
+    assert (v - np.arange(1, 6)).sum() == 0
+
+    # assert last slice correct (which will contain some duplication)
+    i, v = res[3]
+    assert i == 15
+    assert (v - np.arange(3, 8)).sum() == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,7 +50,7 @@ def test_load_audio_short_centered(tone_short, sr):
 
 def test_slice_seconds_right_pad():
     x = np.ones(16)
-    res = slice_seconds(x, 1, 5, remainder_padding_type="right")
+    res = slice_seconds(x, 1, 5, padding_type="right")
     assert len(res) == 4
 
     # assert 1st slice is correct
@@ -66,7 +66,7 @@ def test_slice_seconds_right_pad():
 
 def test_slice_seconds_center_pad():
     x = np.ones(17)
-    res = slice_seconds(x, 1, 5, remainder_padding_type="center")
+    res = slice_seconds(x, 1, 5, padding_type="center")
     assert len(res) == 4
 
     # assert 1st slice is correct
@@ -80,9 +80,9 @@ def test_slice_seconds_center_pad():
     assert (v - np.array([1, 1, 1, 0, 0])).sum() == 0
 
 
-def test_slice_seconds_right_aligned_pad():
+def test_slice_seconds_right_align_pad():
     x = np.arange(1, 8)
-    res = slice_seconds(x, 1, 5, remainder_padding_type="right-aligned")
+    res = slice_seconds(x, 1, 5, padding_type="right-align")
     assert len(res) == 2
 
     # assert 1st slice is correct
@@ -91,6 +91,6 @@ def test_slice_seconds_right_aligned_pad():
     assert (v - np.arange(1, 6)).sum() == 0
 
     # assert last slice correct (which will contain some duplication)
-    i, v = res[3]
-    assert i == 15
+    i, v = res[1]
+    assert i == 5
     assert (v - np.arange(3, 8)).sum() == 0


### PR DESCRIPTION
Resolves #28 by handling remainder data in `utils.py/slice_seconds` if the chosen timestep does not divide the data evenly.

Two options are provided:
* Center (default) provides zero-padding on the left and right to roughly center the data (more padding on the right side if not symmetric).  `Example: [0, 1, 1, 0, 0]`
* Right provides padding only on the right side.  `Example: [1, 1, 0, 0, 0]`